### PR TITLE
Make it possible to disable plugins that are enabled by default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
     - collectd-plugins-enable
     - collectd-plugins-configure
 
-- name: plugins | disable
+- name: plugins | disable (remove configuration file)
   file:
     dest: "/etc/collectd/collectd.conf.d/{{ item }}.conf"
     state: absent
@@ -36,6 +36,37 @@
     - collectd
     - collectd-plugins
     - collectd-plugins-disable
+    - collectd-plugins-remove-configuration-file
+
+- name: plugins | disable (remove LoadPlugin)
+  lineinfile:
+    path: /etc/collectd/collectd.conf
+    state: absent
+    regexp: "^LoadPlugin {{ item }}"
+  with_items: "{{ collectd_plugins_absent | default([]) }}"
+  notify: restart collectd
+  tags:
+    - configuration
+    - collectd
+    - collectd-plugins
+    - collectd-plugins-disable
+    - collectd-plugins-remove-load-plugin
+
+- name: plugins | disable (remove configuration block)
+  blockinfile:
+    path: /etc/collectd/collectd.conf
+    state: absent
+    marker: "{mark}"
+    marker_begin: "<Plugin {{ item }}>"
+    marker_end: '</Plugin>'
+  with_items: "{{ collectd_plugins_absent | default([]) }}"
+  notify: restart collectd
+  tags:
+    - configuration
+    - collectd
+    - collectd-plugins
+    - collectd-plugins-disable
+    - collectd-plugins-remove-configuration-block
 
 - name: start and enable service
   service:

--- a/templates/etc/collectd/collectd.conf.d/rrdtool.conf.j2
+++ b/templates/etc/collectd/collectd.conf.d/rrdtool.conf.j2
@@ -1,0 +1,20 @@
+# {{ ansible_managed }}
+
+LoadPlugin rrdtool
+
+<Plugin rrdtool>
+        DataDir "/var/lib/collectd/rrd"
+#       CacheTimeout 120
+#       CacheFlush 900
+#       WritesPerSecond 30
+#       CreateFilesAsync false
+#       RandomTimeout 0
+#
+# The following settings are rather advanced
+# and should usually not be touched:
+#       StepSize 10
+#       HeartBeat 20
+#       RRARows 1200
+#       RRATimespan 158112000
+#       XFF 0.1
+</Plugin>


### PR DESCRIPTION
To disable for example `rrdtool` in Ubuntu 18.04. @tersmitten Disabling `rrdtool` will save a lot of IOPS every 40 seconds.