### PR TITLE
Fix deprecation warning in Apache plugin

### DIFF
--- a/templates/etc/collectd/collectd.conf.d/apache.conf.j2
+++ b/templates/etc/collectd/collectd.conf.d/apache.conf.j2
@@ -12,8 +12,8 @@ LoadPlugin apache
 {% if item.password is defined %}
     Password "{{ item.password }}"
 {% endif %}
-    VerifyPeer "{{ item.verify_peer | default(true) }}"
-    VerifyHost "{{ item.verify_host | default(true) }}"
+    VerifyPeer {{ item.verify_peer | default(true) }}
+    VerifyHost {{ item.verify_host | default(true) }}
 {% if item.ca_cert_file is defined %}
     CACert "{{ item.ca_cert_file }}"
 {% endif %}


### PR DESCRIPTION
Warning:
```
apache plugin: Using string value `True' for boolean option `VerifyPeer' is deprecated and will be removed in future releases. Use unquoted true or false instead.
apache plugin: Using string value `True' for boolean option `VerifyHost' is deprecated and will be removed in future releases. Use unquoted true or false instead.
```
