### PR TITLE
Workaround for bug with python plugins in Ubuntu 20.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,17 @@
     - collectd
     - collectd-additional
 
+- name: configure
+  ansible.builtin.template:
+    src: "etc/default/collectd.j2"
+    dest: "/etc/default/collectd"
+    mode: 0644
+  notify: restart collectd
+  tags:
+    - configuration
+    - collectd
+    - collectd-configure
+
 - name: plugins | enable and configure
   ansible.builtin.template:
     src: "etc/collectd/collectd.conf.d/{{ item }}.conf.j2"

--- a/templates/etc/default/collectd.j2
+++ b/templates/etc/default/collectd.j2
@@ -1,0 +1,22 @@
+# {{ ansible_managed }}
+
+# /etc/default/collectd
+
+# 0: start collectd on boot, 1: do not start collectd on boot
+# default: 0
+DISABLE=0
+
+# 0: start collectd in stand-alone mode, 1: monitor collectd using collectdmon
+# default: 1
+USE_COLLECTDMON=1
+
+# number of seconds to wait for collectd to shut down
+# default: 30
+MAXWAIT=30
+
+# 0: do not enable core-files, 1: enable core-files ... if collectd crashes
+# default: 0
+ENABLE_COREFILES=0
+
+# workaround for bug with python plugins in Ubuntu 20.04 (see: https://bugs.launchpad.net/ubuntu/+source/collectd/+bug/1872281)
+LD_PRELOAD=/usr/lib/python3.8/config-3.8-x86_64-linux-gnu/libpython3.8.so


### PR DESCRIPTION
Workaround for bug with python plugins in Ubuntu 20.04. See: https://bugs.launchpad.net/ubuntu/+source/collectd/+bug/1872281

@tersmitten What is the best way to make this conditional?