### PR TITLE
Fix df.conf in Debian

### DIFF
--- a/templates/etc/collectd/collectd.conf.d/df.conf.j2
+++ b/templates/etc/collectd/collectd.conf.d/df.conf.j2
@@ -19,7 +19,7 @@ LoadPlugin df
   FSType mqueue
   IgnoreSelected true
   ReportByDevice false
-{% if ansible_distribution != 'Ubuntu' or ansible_distribution_major_version is version('20', '<') %}
+{% if ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('20', '<') %}
   ReportReserved true
 {% endif %}
   ValuesAbsolute true


### PR DESCRIPTION
@tersmitten `ReportReserved` is removed in Collectd 5.5. All supported Debian versions use Collectd 5.5 or higher