### PR TITLE
Fix df.conf in up-to-date Ubuntu 18.04

### DIFF
--- a/templates/etc/collectd/collectd.conf.d/df.conf.j2
+++ b/templates/etc/collectd/collectd.conf.d/df.conf.j2
@@ -19,6 +19,9 @@ LoadPlugin df
   FSType mqueue
   IgnoreSelected true
   ReportByDevice false
+{% if ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('18', '<') %}
+  ReportReserved true
+{% endif %}
   ValuesAbsolute true
   ValuesPercentage true
   ReportInodes true

--- a/templates/etc/collectd/collectd.conf.d/df.conf.j2
+++ b/templates/etc/collectd/collectd.conf.d/df.conf.j2
@@ -19,9 +19,6 @@ LoadPlugin df
   FSType mqueue
   IgnoreSelected true
   ReportByDevice false
-{% if ansible_distribution == 'Ubuntu' and ansible_distribution_major_version is version('20', '<') %}
-  ReportReserved true
-{% endif %}
   ValuesAbsolute true
   ValuesPercentage true
   ReportInodes true


### PR DESCRIPTION
@tersmitten ReportReserved is removed in Collectd 5.5. Up-to-date Ubuntu 18.04 uses Collectd 5.7.2
